### PR TITLE
Create report for January 21, 2026

### DIFF
--- a/reports/2026-01-21.md
+++ b/reports/2026-01-21.md
@@ -1,0 +1,41 @@
+# Report - 21-01-2026
+
+* **Period:** 07012026 - 21012026
+* **Previous report:** https://github.com/qdrvm/polkadot-sdk-reports/blob/master/reports/2026-01-07.md
+* **Treasury grant scope**: Ref. 1689: Polkadot-SDK improvements proposal 1
+
+### Main highlights:
+
+#### State sync (RAM issue):
+* [PR 9247](https://github.com/paritytech/polkadot-sdk/pull/9247) addressed comments from @cheme . Suggestions from him:
+    * move new code from StateDb to db/src/lib.rs
+    * add checking trie is complete in block import function
+    * key range instead of all keys?
+     
+#### State sync v3:
+* [PR 10296](https://github.com/paritytech/polkadot-sdk/pull/10296) is still awaiting review by Parity (@skunert is assigned as reviewer)
+    
+#### Archive storage (same status)
+* Main PR https://github.com/paritytech/polkadot-sdk/pull/10029/ is ready
+    * Paseo archive node was synchronized, size is twice smaller than the node synced by latest Polkadot-SDK release
+* Related PR https://github.com/paritytech/parity-common/pull/951 has two approvals and ready for merge
+
+#### Shadow integration (same status)
+
+* https://github.com/paritytech/polkadot-sdk/pull/10055 is ready and on hold for now:
+    * The call with Javier has been conducted
+        * Javier confirmed that our approach of shadow integration into zombienet-sdk makes sense
+        * this work is on pause until approval from Parity
+
+#### Multi-slot collation (same status):
+
+* [PR 10022](https://github.com/paritytech/polkadot-sdk/pull/10022) has been updated to the new logic for slot calculation as suggested by Sebastian
+    * PR has been reviewed by Basti with `Generally looking good` comment
+    * All review comments has been fixed
+
+#### Faster erasure-coding (RFC-139)
+* PR to erasure coding repo with optimizations: https://github.com/paritytech/erasure-coding/pull/16
+    * switched to `https://crates.io/crates/reed-solomon-simd`
+* PR with the new Erasure coding to polkadot-sdk: https://github.com/paritytech/polkadot-sdk/pull/10116
+    * Addressed all comments
+ 


### PR DESCRIPTION
Added a new report detailing updates and highlights for the period from January 7, 2026, to January 21, 2026, including various PRs and their statuses.